### PR TITLE
cleanup openh264 build for Android

### DIFF
--- a/build/android-common.sh
+++ b/build/android-common.sh
@@ -206,7 +206,7 @@ get_android_arch() {
 }
 
 get_common_includes() {
-    echo "-isystem ${ANDROID_NDK_ROOT}/toolchains/llvm/prebuilt/${TOOLCHAIN}/sysroot/usr/include -isystem ${ANDROID_NDK_ROOT}/toolchains/llvm/prebuilt/${TOOLCHAIN}/sysroot/usr/include/${BUILD_HOST} -isystem ${ANDROID_NDK_ROOT}/toolchains/llvm/prebuilt/${TOOLCHAIN}/sysroot/usr/local/include"
+    echo ""
 }
 
 get_common_cflags() {

--- a/build/android-common.sh
+++ b/build/android-common.sh
@@ -206,7 +206,7 @@ get_android_arch() {
 }
 
 get_common_includes() {
-    echo "-isystem ${ANDROID_NDK_ROOT}/toolchains/llvm/prebuilt/${TOOLCHAIN}/sysroot/usr/include -isystem ${ANDROID_NDK_ROOT}/toolchains/llvm/prebuilt/${TOOLCHAIN}/sysroot/usr/include/${TARGET_HOST} -isystem ${ANDROID_NDK_ROOT}/toolchains/llvm/prebuilt/${TOOLCHAIN}/sysroot/usr/local/include"
+    echo "-isystem ${ANDROID_NDK_ROOT}/toolchains/llvm/prebuilt/${TOOLCHAIN}/sysroot/usr/include -isystem ${ANDROID_NDK_ROOT}/toolchains/llvm/prebuilt/${TOOLCHAIN}/sysroot/usr/include/${BUILD_HOST} -isystem ${ANDROID_NDK_ROOT}/toolchains/llvm/prebuilt/${TOOLCHAIN}/sysroot/usr/local/include"
 }
 
 get_common_cflags() {

--- a/build/android-common.sh
+++ b/build/android-common.sh
@@ -206,7 +206,7 @@ get_android_arch() {
 }
 
 get_common_includes() {
-    echo "-I${ANDROID_NDK_ROOT}/toolchains/llvm/prebuilt/${TOOLCHAIN}/sysroot/usr/include -I${ANDROID_NDK_ROOT}/toolchains/llvm/prebuilt/${TOOLCHAIN}/sysroot/usr/local/include"
+    echo "-isystem ${ANDROID_NDK_ROOT}/toolchains/llvm/prebuilt/${TOOLCHAIN}/sysroot/usr/include -isystem ${ANDROID_NDK_ROOT}/toolchains/llvm/prebuilt/${TOOLCHAIN}/sysroot/usr/include/${TARGET_HOST} -isystem ${ANDROID_NDK_ROOT}/toolchains/llvm/prebuilt/${TOOLCHAIN}/sysroot/usr/local/include"
 }
 
 get_common_cflags() {

--- a/build/android-openh264.sh
+++ b/build/android-openh264.sh
@@ -35,31 +35,21 @@ LDFLAGS=$(get_ldflags ${LIB_NAME})
 
 case ${ARCH} in
     arm-v7a-neon)
+      ASM_ARCH=arm
         # Enabling NEON causes undefined symbol error for WelsCopy8x8_neon
         # CFLAGS+=" -DHAVE_NEON"
     ;;
     arm64-v8a)
+        ASM_ARCH=arm64
         CFLAGS+=" -DHAVE_NEON_AARCH64"
     ;;
     x86*)
+        ASM_ARCH=x86
         CFLAGS+=" -DHAVE_AVX2"
     ;;
 esac
 
 cd ${BASEDIR}/src/${LIB_NAME} || exit 1
-
-# MAKE SURE THAT ASM IS ENABLED FOR ALL IOS ARCHITECTURES
-${SED_INLINE} 's/arm64 aarch64/arm64% aarch64/g' ${BASEDIR}/src/${LIB_NAME}/build/arch.mk
-${SED_INLINE} 's/%86 x86_64,/%86 x86_64 x86-64,/g' ${BASEDIR}/src/${LIB_NAME}/build/arch.mk
-${SED_INLINE} 's/filter-out arm64,/filter-out arm64%,/g' ${BASEDIR}/src/${LIB_NAME}/build/arch.mk
-${SED_INLINE} 's/CFLAGS += -DHAVE_NEON/#CFLAGS += -DHAVE_NEON/g' ${BASEDIR}/src/${LIB_NAME}/build/arch.mk
-${SED_INLINE} 's/ifeq (\$(ASM_ARCH), arm64)/ifneq (\$(filter arm64%, \$(ASM_ARCH)),)/g' ${BASEDIR}/src/${LIB_NAME}/codec/common/targets.mk
-${SED_INLINE} 's/ifeq (\$(ASM_ARCH), x86)/ifneq (\$(filter %86 x86-64, \$(ASM_ARCH)),)/g' ${BASEDIR}/src/${LIB_NAME}/codec/common/targets.mk
-${SED_INLINE} 's/ifeq (\$(ASM_ARCH), arm)/ifneq (\$(filter armv%, \$(ASM_ARCH)),)/g' ${BASEDIR}/src/${LIB_NAME}/codec/common/targets.mk
-
-# DO NOT USE DEFAULT ANDROID ARCH FLAGS
-${SED_INLINE} 's/ CFLAGS +=/ #CFLAGS +=/g' ${BASEDIR}/src/${LIB_NAME}/build/platform-android.mk
-${SED_INLINE} 's/ LDFLAGS +=/ #LDFLAGS +=/g' ${BASEDIR}/src/${LIB_NAME}/build/platform-android.mk
 
 make clean 2>/dev/null 1>/dev/null
 
@@ -75,6 +65,10 @@ PREFIX="${BASEDIR}/prebuilt/android-$(get_target_build)/${LIB_NAME}" \
 NDKLEVEL="${API}" \
 NDKROOT="${ANDROID_NDK_ROOT}" \
 NDK_TOOLCHAIN_VERSION=clang \
+TOOLCHAINPREFIX=dummy_prefix \
+TOOLCHAIN_NAME=dummy_name \
+AR="${ANDROID_NDK_ROOT}/toolchains/llvm/prebuilt/${TOOLCHAIN}/bin/${AR}" \
+ASM_ARCH=${ASM_ARCH} \
 TARGET="android-${API}" \
 install-static || exit 1
 

--- a/build/android-openh264.sh
+++ b/build/android-openh264.sh
@@ -55,9 +55,9 @@ make clean 2>/dev/null 1>/dev/null
 
 make -j$(get_cpu_count) \
 ARCH="$(get_toolchain_arch)" \
-CC="${ANDROID_NDK_ROOT}/toolchains/llvm/prebuilt/${TOOLCHAIN}/bin/${CC}" \
+CC="$CC" \
 CFLAGS="$CFLAGS" \
-CXX="${ANDROID_NDK_ROOT}/toolchains/llvm/prebuilt/${TOOLCHAIN}/bin/${CXX}" \
+CXX="$CXX" \
 CXXFLAGS="${CXXFLAGS}" \
 LDFLAGS="$LDFLAGS" \
 OS=android \
@@ -65,9 +65,7 @@ PREFIX="${BASEDIR}/prebuilt/android-$(get_target_build)/${LIB_NAME}" \
 NDKLEVEL="${API}" \
 NDKROOT="${ANDROID_NDK_ROOT}" \
 NDK_TOOLCHAIN_VERSION=clang \
-TOOLCHAINPREFIX=dummy_prefix \
-TOOLCHAIN_NAME=dummy_name \
-AR="${ANDROID_NDK_ROOT}/toolchains/llvm/prebuilt/${TOOLCHAIN}/bin/${AR}" \
+AR="$AR" \
 ASM_ARCH=${ASM_ARCH} \
 TARGET="android-${API}" \
 install-static || exit 1


### PR DESCRIPTION
cleaner way to build openh264, not changing the sources at all

includes some files that were missing for arm32 build, as described in https://github.com/tanersener/mobile-ffmpeg/issues/367

This builds smoothly with NDK r21 and NDK r20 on Ubuntu.