### PR TITLE
👷 Add `--speed` to android.sh CUSTOM_OPTIONS

### DIFF
--- a/tools/release/android.sh
+++ b/tools/release/android.sh
@@ -5,7 +5,7 @@
 
 export BASEDIR=$(pwd)
 export PACKAGE_DIRECTORY="${BASEDIR}/../../prebuilt/android-aar/mobile-ffmpeg"
-export CUSTOM_OPTIONS="--disable-arm-v7a --enable-android-zlib --enable-android-media-codec"
+export CUSTOM_OPTIONS="--speed --disable-arm-v7a --enable-android-zlib --enable-android-media-codec"
 export GPL_PACKAGES="--enable-gpl --enable-libvidstab --enable-x264 --enable-x265 --enable-xvidcore"
 export FULL_PACKAGES="--enable-fontconfig --enable-freetype --enable-fribidi --enable-gmp --enable-gnutls --enable-kvazaar --enable-lame --enable-libaom --enable-libass --enable-libiconv --enable-libilbc --enable-libtheora --enable-libvorbis --enable-libvpx --enable-libwebp --enable-libxml2 --enable-opencore-amr --enable-opus --enable-shine --enable-snappy --enable-soxr --enable-speex --enable-twolame --enable-vo-amrwbenc --enable-wavpack"
 


### PR DESCRIPTION
## Why?
To replicate the same `FFprobe` output produced by the `FFmpeg` binaries found on their [download page](https://ffmpeg.org/download.html) as close as possible.

## What?
Currently, the mobile-ffmpeg published gradle packages prioritize bundle output file size while sacrificing some common details one might normally find in an `FFprobe` output.

## For example,
Using `implementation 'com.arthenica:mobile-ffmpeg-full:4.4'` an `FFprobe` output is missing these properties:

■ `profile` and `codec_long_name` both used to describe
- **Video**: H.265 HDR technology used, color gamut n stuff 🌈
- **Audio**: DTS surround sound, lossless DTS-HD MA usage to passthrough to receiver 🔊

## Solution A
Rename the `--speed` option to `--size` and flip flop the two defaults? 🤷‍♂️ Idk I feel like not too many people are worried about saving a few Mb's in the year 2021.

## Solution B
Publish an additional set of packages adding the `speed` namespace?

----

#### I did try though :D
My attempt at cloning this repo and building the `mobile-ffmpeg.aar` on my local machine resulted in kernel panics from my logic board overheating. 🔥 Certainly a cleaning well overdue lol