### PR TITLE
fixing #634

### DIFF
--- a/android/app/src/main/cpp/saf_wrapper.c
+++ b/android/app/src/main/cpp/saf_wrapper.c
@@ -91,7 +91,6 @@ static AVIOContext *create_fd_avio_context(const char *filename, int flags) {
 static void close_fd_avio_context(AVIOContext *ctx) {
     if (fd_seek(ctx->opaque, 0, AVSEEK_SIZE) >= 0) {
         int fd = (int)ctx->opaque;
-        close(fd);
         closeParcelFileDescriptor(fd);
     }
     ctx->opaque = NULL;


### PR DESCRIPTION
attempted to close file descriptor XX, expected to be unowned, actually owned by ParcelFileDescriptor XXX
