### PR TITLE
Fix version check bug

### DIFF
--- a/ios.sh
+++ b/ios.sh
@@ -1009,7 +1009,7 @@ elif [[ ${DETECTED_IOS_SDK_VERSION} != 10* ]]; then
 fi
 
 # DISABLE x86-64-mac-catalyst architecture on IOS versions lower than 13
-if [[ ${DETECTED_IOS_SDK_VERSION} != 13* || ${DETECTED_IOS_SDK_VERSION} != 14* ]] && [[ -z ${BUILD_FORCE} ]] && [[ ${ENABLED_ARCHITECTURES[${ARCH_X86_64_MAC_CATALYST}]} -eq 1 ]]; then
+if [[ ${DETECTED_IOS_SDK_VERSION} != 13* && ${DETECTED_IOS_SDK_VERSION} != 14* ]] && [[ -z ${BUILD_FORCE} ]] && [[ ${ENABLED_ARCHITECTURES[${ARCH_X86_64_MAC_CATALYST}]} -eq 1 ]]; then
   echo -e "INFO: Disabled x86-64-mac-catalyst architecture which is not supported on SDK ${DETECTED_IOS_SDK_VERSION}\n" 1>>"${BASEDIR}/build.log" 2>&1
   disable_arch "x86-64-mac-catalyst"
 fi


### PR DESCRIPTION
I found this little  bug. The version condition should be `&&` instead of `||`.

> If the SDK version is **not** 13 **and** is **not** 14 then:
>    -> disable x86-64-mac-catalyst architecture